### PR TITLE
[FIX] wrong date format

### DIFF
--- a/utils/time.go
+++ b/utils/time.go
@@ -6,7 +6,7 @@ import (
 )
 
 const EscherDateFormat = "20060102T150405Z07"
-const HTTPHeaderFormat = "Fri, 02 Jan 2006 15:04:05 MST"
+const HTTPHeaderFormat = "Mon, 02 Jan 2006 15:04:05 MST"
 
 var acceptedTimeFormats = []string{
 	EscherDateFormat,


### PR DESCRIPTION
Invalid date format returned when the dateHeaderName = 'date'
go format requires Mon instead of Fri